### PR TITLE
Fix regex - some images were not being downloaded

### DIFF
--- a/medium-export-image-fill.py
+++ b/medium-export-image-fill.py
@@ -82,7 +82,7 @@ for article_count, article_filename in enumerate(articles):
     with open(article_filename, 'r') as file:
       article_contents = file.read()
 
-    images = re.findall(r'(<img class="graf-image"(.*?)src="(.*?)">)', article_contents)
+    images = re.findall(r'(<img class="graf-image"(.*?) src="(.*?)">)', article_contents)
 
     # Loop 2: Go through all the images in an article
     # -----------------------------------------------


### PR DESCRIPTION
The original code searched src=".." pattern and would pick things like data-external-src=".." causing incorrect/missing downloads

ie. If the dom has

<img class="graf-image" ..... data-external-src="https://source-may-not-even-exist" src="https://cdn-images-1.medium.com/max/800/0*DhI3q3JKa139yuB2.jpg">

the script would try to download from https://source-may-not-even-exist

I tried running it both ways on my page medium.com/@rishirdua

Before fix: 131 images downloaded
After fix: 172 images downloaded