### PR TITLE
Fix: New image id regex for Unsplash images

### DIFF
--- a/medium-export-image-fill.py
+++ b/medium-export-image-fill.py
@@ -104,7 +104,7 @@ for article_count, article_filename in enumerate(articles):
         skip_download = True
 
       # Get the image id, used to determine local filename
-      image_id = re.findall(r'\/(([^\/]*?)\.([a-z]+))$', image_server_url)[0][0]
+      image_id = re.findall(r'\/([^\/]+)$', image_server_url)[0]
 
       # Update the user
       progress_string = "[%i/%i] %s %s..." %\


### PR DESCRIPTION
My archive includes urls without a filename extension, e.g. 
`<img class="graf-image" data-image-id="0*NSVDFiE7cAn15tQW" data-width="4240" data-height="2384" src="https://cdn-images-1.medium.com/max/1200/0*NSVDFiE7cAn15tQW">`

I think those are just Unsplash images for me. I’d still want to download them to have a proper archive.  
The manual uploads I checked seem to have a file extension.

I changed the regex to be a bit more flexible. Instead of checking for file extensions, it just gets everything after the last slash in the src. 

We could instead also read from `data-image-id` for the id I suppose.

Files are still stored with those names, so a disadvantage is that e.g. macOS preview won’t render them as images. My browser (Chromium) renders them just fine though. I wouldn’t expect any regressions there.

I only tested with my download. 